### PR TITLE
fix: update player currentTime to use milliseconds

### DIFF
--- a/packages/path-kaltura/src/use-load-media.tsx
+++ b/packages/path-kaltura/src/use-load-media.tsx
@@ -46,7 +46,7 @@ export const useLoadMedia = (options: UseLoadMediaOptions): LoadMediaState => {
 
   const updatePlayerCurrentTime = () => {
     if(playerRef.current){
-      playerTimeSubject.current.next(playerRef.current.currentTime);
+      playerTimeSubject.current.next(playerRef.current.currentTime * 1000);
     }
   };
 
@@ -131,7 +131,7 @@ export const useLoadMedia = (options: UseLoadMediaOptions): LoadMediaState => {
       if(!playerRef.current
         || typeof playerRef.current.currentTime !== 'number') return;
       if (pause) playerRef.current.pause();
-      playerRef.current.currentTime = time;
+      playerRef.current.currentTime = time / 1000;
     };
 
     const loadPlayer = () => {


### PR DESCRIPTION
Temporary hotfix to use milliseconds instead of seconds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kaltura-path-ui-kit/143)
<!-- Reviewable:end -->
