### PR TITLE
feat: add extended buttons props for attributes capabilities

### DIFF
--- a/packages/path-inputs/src/button.tsx
+++ b/packages/path-inputs/src/button.tsx
@@ -53,9 +53,13 @@ export interface ButtonProps {
    * @default undefined
    */
   style?: CSSProperties;
-}
 
-type AgregatedButtonProps = Omit<NativeButtonProps, keyof ButtonProps | 'children'> & ButtonProps;
+  /**
+   * Native HTMLButton Props
+   * @default undefined
+   */
+  nativeButtonProps?: NativeButtonProps;
+}
 
 const withClassName = (element: React.ReactElement, className: string = '') => {
   return React.cloneElement(element, { className });
@@ -68,7 +72,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
       'transition': 'none'
     }
   },
-  'btn': (props: AgregatedButtonProps) => ({
+  'btn': (props: ButtonProps) => ({
     height: props.layout === 'vertical' ? '60px' : '32px',
     minWidth: props.layout === 'vertical' ? '80px' : '34px',
     boxShadow: 'none',
@@ -78,7 +82,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
     fontWeight: theme.button.fontWeight,
     borderRadius: theme.button.borderRadius,
   }),
-  'btnDefault': (props: AgregatedButtonProps) => ({
+  'btnDefault': (props: ButtonProps) => ({
     '&:focus': {
       backgroundColor: '#ffffff',
       border: `thin solid ${theme.colors.grayscale4}`,
@@ -107,7 +111,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
       backgroundColor: 'transparent'
     },
   }),
-  'btnCTA': (props: AgregatedButtonProps) => ({
+  'btnCTA': (props: ButtonProps) => ({
     boxShadow: 'none',
     color: '#ffffff',
     backgroundColor: '#008297',
@@ -138,7 +142,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
       backgroundColor: 'transparent'
     },
   }),
-  'btnBorderless': (props: AgregatedButtonProps) => ({
+  'btnBorderless': (props: ButtonProps) => ({
     color: theme.colors.grayscale1,
     backgroundColor: 'transparent',
     border: 'none',
@@ -204,7 +208,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
   'btnIconOnly': {
     padding: '0px 0px !important',
   },
-  'btnContent': (props: AgregatedButtonProps) => ({
+  'btnContent': (props: ButtonProps) => ({
     display: 'flex',
     flexDirection: props.layout === 'vertical' ? 'column' : 'row',
     alignItems: 'center',
@@ -233,9 +237,9 @@ const useStyles = createUseStyles((theme: Theme) => ({
 /**
  * A button means an operation (or a series of operations). Clicking a button will trigger corresponding business logic.
  */
-export function Button(props: AgregatedButtonProps) {
+export function Button(props: ButtonProps) {
   const classes = useStyles(props);
-  const { label, disabled, onClick, icon, isProcessing, className, style, type, ...buttonAttributes } = props;
+  const { label, disabled, onClick, icon, isProcessing, className, style, type, nativeButtonProps } = props;
   const isCTA = type === 'cta';
   const isBorderLess = type === 'borderless';
   const [isDisabled, setIsDisabled] = useState(false);
@@ -270,7 +274,7 @@ export function Button(props: AgregatedButtonProps) {
   });
 
   return (
-    <AntButton className={btnClass} disabled={isDisabled} style={style} onClick={onClick} {...buttonAttributes}>
+    <AntButton {...nativeButtonProps} className={btnClass} disabled={isDisabled} style={style} onClick={onClick}>
       <div className={btnContentClass}>
         {icon ? withClassName(icon, iconClass) : null}
         {!isProcessing

--- a/packages/path-inputs/src/button.tsx
+++ b/packages/path-inputs/src/button.tsx
@@ -3,6 +3,7 @@ import { createUseStyles, theming, Theme } from '@kaltura-react-ui-kits/path-the
 import { Button as AntButton } from 'antd';
 import { SpinnerBright24Icon, SpinnerDark24Icon } from '@kaltura-react-ui-kits/path-icons';
 import { CSSProperties, useEffect, useState } from 'react';
+import { ButtonProps as AntButtonProps } from 'antd/lib/button';
 
 const classNames = require('classnames');
 
@@ -54,6 +55,8 @@ export interface ButtonProps {
   style?: CSSProperties;
 }
 
+type AgregatedButtonProps = Omit<AntButtonProps, keyof ButtonProps | 'children'> & ButtonProps;
+
 const withClassName = (element: React.ReactElement, className: string = '') => {
   return React.cloneElement(element, { className });
 };
@@ -65,7 +68,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
       'transition': 'none'
     }
   },
-  'btn': (props: ButtonProps) => ({
+  'btn': (props: AgregatedButtonProps) => ({
     height: props.layout === 'vertical' ? '60px' : '32px',
     minWidth: props.layout === 'vertical' ? '80px' : '34px',
     boxShadow: 'none',
@@ -75,7 +78,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
     fontWeight: theme.button.fontWeight,
     borderRadius: theme.button.borderRadius,
   }),
-  'btnDefault': (props: ButtonProps) => ({
+  'btnDefault': (props: AgregatedButtonProps) => ({
     '&:focus': {
       backgroundColor: '#ffffff',
       border: `thin solid ${theme.colors.grayscale4}`,
@@ -104,7 +107,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
       backgroundColor: 'transparent'
     },
   }),
-  'btnCTA': (props: ButtonProps) => ({
+  'btnCTA': (props: AgregatedButtonProps) => ({
     boxShadow: 'none',
     color: '#ffffff',
     backgroundColor: '#008297',
@@ -135,7 +138,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
       backgroundColor: 'transparent'
     },
   }),
-  'btnBorderless': (props: ButtonProps) => ({
+  'btnBorderless': (props: AgregatedButtonProps) => ({
     color: theme.colors.grayscale1,
     backgroundColor: 'transparent',
     border: 'none',
@@ -201,7 +204,7 @@ const useStyles = createUseStyles((theme: Theme) => ({
   'btnIconOnly': {
     padding: '0px 0px !important',
   },
-  'btnContent': (props: ButtonProps) => ({
+  'btnContent': (props: AgregatedButtonProps) => ({
     display: 'flex',
     flexDirection: props.layout === 'vertical' ? 'column' : 'row',
     alignItems: 'center',
@@ -230,9 +233,9 @@ const useStyles = createUseStyles((theme: Theme) => ({
 /**
  * A button means an operation (or a series of operations). Clicking a button will trigger corresponding business logic.
  */
-export function Button(props: ButtonProps) {
+export function Button(props: AgregatedButtonProps) {
   const classes = useStyles(props);
-  const { label, disabled, onClick, icon, isProcessing, className, style, type } = props;
+  const { label, disabled, onClick, icon, isProcessing, className, style, type, ...buttonAttributes } = props;
   const isCTA = type === 'cta';
   const isBorderLess = type === 'borderless';
   const [isDisabled, setIsDisabled] = useState(false);
@@ -267,7 +270,7 @@ export function Button(props: ButtonProps) {
   });
 
   return (
-    <AntButton className={btnClass} disabled={isDisabled} style={style} onClick={onClick}>
+    <AntButton className={btnClass} disabled={isDisabled} style={style} onClick={onClick} {...buttonAttributes}>
       <div className={btnContentClass}>
         {icon ? withClassName(icon, iconClass) : null}
         {!isProcessing

--- a/packages/path-inputs/src/button.tsx
+++ b/packages/path-inputs/src/button.tsx
@@ -3,7 +3,7 @@ import { createUseStyles, theming, Theme } from '@kaltura-react-ui-kits/path-the
 import { Button as AntButton } from 'antd';
 import { SpinnerBright24Icon, SpinnerDark24Icon } from '@kaltura-react-ui-kits/path-icons';
 import { CSSProperties, useEffect, useState } from 'react';
-import { ButtonProps as AntButtonProps } from 'antd/lib/button';
+import { NativeButtonProps } from 'antd/lib/button/button';
 
 const classNames = require('classnames');
 
@@ -55,7 +55,7 @@ export interface ButtonProps {
   style?: CSSProperties;
 }
 
-type AgregatedButtonProps = Omit<AntButtonProps, keyof ButtonProps | 'children'> & ButtonProps;
+type AgregatedButtonProps = Omit<NativeButtonProps, keyof ButtonProps | 'children'> & ButtonProps;
 
 const withClassName = (element: React.ReactElement, className: string = '') => {
   return React.cloneElement(element, { className });

--- a/packages/path-inputs/src/toggle-button.tsx
+++ b/packages/path-inputs/src/toggle-button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CSSProperties, useEffect, useState } from 'react';
 import { Button, ButtonProps } from './button';
-import { ButtonProps as AntButtonProps } from 'antd/lib/button';
+import { NativeButtonProps } from 'antd/lib/button/button';
 
 export type ToggleButtonProps = {
   /** Label of the button
@@ -48,7 +48,7 @@ export type ToggleButtonProps = {
 /**
  * Toggle buttons are buttons that are changing a binary state of a single parameter.
  */
-export function ToggleButton(props: Omit<AntButtonProps, keyof ButtonProps> & ToggleButtonProps) {
+export function ToggleButton(props: Omit<NativeButtonProps, keyof ButtonProps> & ToggleButtonProps) {
   const {isActive, defaultActive, onChange, disabled} = props;
   const [isControlled] = useState(typeof isActive === 'boolean');
   const [active, setActive] = useState(

--- a/packages/path-inputs/src/toggle-button.tsx
+++ b/packages/path-inputs/src/toggle-button.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CSSProperties, useEffect, useState } from 'react';
-import { Button, ButtonProps } from './button';
+import { Button } from './button';
 import { NativeButtonProps } from 'antd/lib/button/button';
 
 export type ToggleButtonProps = {
@@ -43,12 +43,18 @@ export type ToggleButtonProps = {
    * Optional styles of the button
    */
   style?: CSSProperties;
+
+  /**
+   * Native HTMLButton Props
+   * @default undefined
+   */
+  nativeButtonProps?: NativeButtonProps;
 };
 
 /**
  * Toggle buttons are buttons that are changing a binary state of a single parameter.
  */
-export function ToggleButton(props: Omit<NativeButtonProps, keyof ButtonProps> & ToggleButtonProps) {
+export function ToggleButton(props: ToggleButtonProps) {
   const {isActive, defaultActive, onChange, disabled} = props;
   const [isControlled] = useState(typeof isActive === 'boolean');
   const [active, setActive] = useState(

--- a/packages/path-inputs/src/toggle-button.tsx
+++ b/packages/path-inputs/src/toggle-button.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { CSSProperties, useEffect, useState } from 'react';
-import {Button} from './button';
+import { Button, ButtonProps } from './button';
+import { ButtonProps as AntButtonProps } from 'antd/lib/button';
 
 export type ToggleButtonProps = {
   /** Label of the button
@@ -47,18 +48,18 @@ export type ToggleButtonProps = {
 /**
  * Toggle buttons are buttons that are changing a binary state of a single parameter.
  */
-export function ToggleButton(props: ToggleButtonProps) {
+export function ToggleButton(props: Omit<AntButtonProps, keyof ButtonProps> & ToggleButtonProps) {
   const {isActive, defaultActive, onChange, disabled} = props;
   const [isControlled] = useState(typeof isActive === 'boolean');
   const [active, setActive] = useState(
     (typeof isActive === 'boolean' ? isActive : defaultActive) || false
   );
 
-  useEffect(() => {  
+  useEffect(() => {
     if (!isControlled) {
       return;
     }
-    
+
     setActive(isActive || false);
   }, [isActive]);
 


### PR DESCRIPTION
According to https://kaltura.atlassian.net/browse/PATH-973 we need **tabindex** and **autofocus** attributes for buttons.
I decided to provide a full interface from the AntButton to avoid future extension of the attributes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kaltura-path-ui-kit/185)
<!-- Reviewable:end -->
